### PR TITLE
Fix typings for Pixi v 5.3.3

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -100,12 +100,12 @@ export declare class Scrollbox extends PIXI.Container {
     /**
      * handle pointer down on scrollbar
      */
-    private scrollbarDown(e: PIXI.interaction.InteractionEvent): void
+    private scrollbarDown(e: PIXI.InteractionEvent): void
 
     /**
      * handle pointer move on scrollbar
      */
-    private scrollbarMove(e: PIXI.interaction.InteractionEvent): void
+    private scrollbarMove(e: PIXI.InteractionEvent): void
 
     /**
      * handle pointer down on scrollbar


### PR DESCRIPTION
This change resolves a typescript error stemming from the move from PIXI.interaction to PIXI.Interaction in v5.3.3 of Pixi.js