### PR TITLE
fix fade restart bug

### DIFF
--- a/src/scrollbox.js
+++ b/src/scrollbox.js
@@ -526,7 +526,7 @@ export class Scrollbox extends PIXI.Container
      */
     activateFade()
     {
-        if (!this.fade && this.options.fade)
+        if (this.options.fade)
         {
             this.scrollbar.alpha = 1
             this.fade = { wait: this.options.fadeScrollboxWait, duration: 0 }


### PR DESCRIPTION
The timer for fade would not restart with the condition `!this.fade`.