### PR TITLE
Fixed pointer down for vertical scrollbar logic

### DIFF
--- a/src/scrollbox.js
+++ b/src/scrollbox.js
@@ -514,7 +514,7 @@ export class Scrollbox extends PIXI.Container {
         }
         if (this.isScrollbarVertical) {
             if (local.x > this.boxWidth - this.scrollbarSize) {
-                if (local.y >= this.scrollbarTop && local.y <= this.scrollbarTop + this.scrollbarWidth) {
+                if (local.y >= this.scrollbarTop && local.y <= this.scrollbarTop + this.scrollbarHeight) {
                     this.pointerDown = { type: 'vertical', last: local }
                 }
                 else {


### PR DESCRIPTION
I'm not 100% sure, but looks like `this.scrollbarTop + this.scrollbarHeight` should be used for determining the lower margin of a scroll handle